### PR TITLE
Audit fixes

### DIFF
--- a/contracts/MarinateReceiver.sol
+++ b/contracts/MarinateReceiver.sol
@@ -48,11 +48,11 @@ contract MarinateReceiver is AccessControl, ReentrancyGuard {
     }
 
     function addDistributedToken(address token) external onlyAdmin {
-        distributedTokens.add(token);
+        require(distributedTokens.add(token), "Distribution token exists");
     }
 
     function removeDistributedToken(address token) external onlyAdmin {
-        distributedTokens.remove(token);
+        require(distributedTokens.remove(token), "Distribution token does not exist");
     }
 
     function setMarinateAddress(address marinate) external onlyAdmin {

--- a/contracts/MarinateV2.sol
+++ b/contracts/MarinateV2.sol
@@ -307,6 +307,7 @@ contract MarinateV2 is AccessControl, IERC721Receiver, ReentrancyGuard, ERC20, C
      * @param limit upper limit for deposits
      */
     function setDepositLimit(uint256 limit) external onlyAdmin {
+        require(limit < IERC20(UMAMI).totalSupply(), "Deposit limit cannot be greater than totalSupply");
         depositLimit = limit;
     }
 

--- a/contracts/MarinateV2.sol
+++ b/contracts/MarinateV2.sol
@@ -213,6 +213,9 @@ contract MarinateV2 is AccessControl, IERC721Receiver, ReentrancyGuard, ERC20, C
         for (uint256 i = 0; i < numberOfRewardTokens; i++) {
             address token = rewardTokens.at(i);
             uint256 amount = toBePaid[token][user];
+            if (amount == 0) {
+                continue;
+            }
             IERC20(token).safeTransfer(user, amount);
             emit RewardClaimed(token, user, amount);
             delete toBePaid[token][user];
@@ -265,15 +268,6 @@ contract MarinateV2 is AccessControl, IERC721Receiver, ReentrancyGuard, ERC20, C
      */
     function addApprovedRewardToken(address token) external onlyAdmin {
         require(rewardTokens.add(token), "Reward token exists");
-    }
-
-    /**
-     * @notice remove a reward token
-     * @param token the address of the token to remove
-     */
-    function removeApprovedRewardToken(address token) external onlyAdmin {
-        require(IERC20(token).balanceOf(address(this)) == 0, "Reward token not completely claimed by everyone yet");
-        require(rewardTokens.remove(token), "Reward token does not exist");
     }
 
     /**

--- a/contracts/MarinateV2.sol
+++ b/contracts/MarinateV2.sol
@@ -121,7 +121,7 @@ contract MarinateV2 is AccessControl, IERC721Receiver, ReentrancyGuard, ERC20, C
         UMAMI = _UMAMI;
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(ADMIN_ROLE, msg.sender);
-        rewardTokens.add(_UMAMI);
+        require(rewardTokens.add(_UMAMI), "Reward token already exists");
         stakeEnabled = true;
         withdrawEnabled = false;
         transferEnabled = true;
@@ -264,8 +264,7 @@ contract MarinateV2 is AccessControl, IERC721Receiver, ReentrancyGuard, ERC20, C
      * @param token the address of the token to be paid in
      */
     function addApprovedRewardToken(address token) external onlyAdmin {
-        require(!rewardTokens.contains(token), "Reward token exists");
-        rewardTokens.add(token);
+        require(rewardTokens.add(token), "Reward token exists");
     }
 
     /**
@@ -273,9 +272,8 @@ contract MarinateV2 is AccessControl, IERC721Receiver, ReentrancyGuard, ERC20, C
      * @param token the address of the token to remove
      */
     function removeApprovedRewardToken(address token) external onlyAdmin {
-        require(rewardTokens.contains(token), "Reward token does not exist");
         require(IERC20(token).balanceOf(address(this)) == 0, "Reward token not completely claimed by everyone yet");
-        rewardTokens.remove(token);
+        require(rewardTokens.remove(token), "Reward token does not exist");
     }
 
     /**

--- a/test/MarinateV2.spec.js
+++ b/test/MarinateV2.spec.js
@@ -274,12 +274,6 @@ describe("MarinateV2", async function () {
       await expect(MarinateV2.addApprovedRewardToken(MockedERC20.address)).to.be.revertedWith("Reward token exists");
     });
 
-    it("RemoveReward Token", async function () {
-      await MarinateV2.addApprovedRewardToken(MockedERC20.address);
-      await MarinateV2.removeApprovedRewardToken(MockedERC20.address);
-      await expect(MarinateV2.removeApprovedRewardToken(MockedERC20.address)).to.be.revertedWith("");
-    });
-
     it("Add Reward Token - No duplicates", async function () {
       await expect(MarinateV2.addApprovedRewardToken(MockedUMAMI.address)).to.be.revertedWith("Reward token exists");
     });
@@ -356,20 +350,6 @@ describe("MarinateV2", async function () {
       expect(accountReward1).to.equal(one);
       expect(Reward).to.equal(half);
       expect(Reward1).to.equal(half);
-    });
-  });
-
-  describe("#removeApprovedRewardToken", async function () {
-    beforeEach(async () => {
-      await setup();
-      const _MockedERC20 = await ethers.getContractFactory("MockERC20");
-      MockedERC20 = await _MockedERC20.deploy("MCK", "MCK");
-    });
-
-    it("reverts if already added", async function () {
-      await expect(MarinateV2.connect(owner).removeApprovedRewardToken(MockedERC20.address)).to.revertedWith(
-        "Reward token does not exist",
-      );
     });
   });
 


### PR DESCRIPTION
> Medium - ContractWhitelist.sol - `isEligibleSender` which is a modifier applied to limit access on stake is now blocking multisig wallets due to `tx.origin == msg.sender` .

It was already the case that we didn't support smart contract wallets by default, any smart contract that we want to allow to interact with marinate needs to be whitelisted, which is an already covered case in the modifier
```solidity
modifier isEligibleSender() {
    if (!isSenderEOA()) {
        require(whitelistedContracts[msg.sender], "ContractWhitelist: Contract must be whitelisted");
    }
    _;
}
```
---
> Low - MarinateV2.sol & MarinateReciever.sol - unchecked return values:
`MarinateV2.constructor`: `rewardTokens.add(_UMAMI)`
`MarinateV2.addApprovedRewardToken`: `rewardTokens.add(token)`
`MarinateV2.removeApprovedRewardToken`: `rewardTokens.remove(token)`
`MarinateReceiver.addDistributedToken`: `distributedTokens.add(token)`
`MarinateReceiver.removeDistributedToken`: `distributedTokens.remove(token)`
Recommendation: wrap in require statements

**Done**

---
> UNRESOLVED Medium - MarinateV2.sol - `addApprovedMultiplierToken`, `setScale` & `setDepositLevel`: new values are not validated before setting. For instance, there's no upper nor lower limit for mulptiplier that is set in `addApprovedMultiplierToken`.
fix#1 - NFT logic and setScale are removed, hence first two issues are no longer relevant. body of `setDepositLimit` is unchanged hence issue persists partially only for that case.

Check the amount is less than umami total supply
---

> Medium - MarinateV2.sol - Regarding `removeApprovedRewardToken`, `require(IERC20(token).balanceOf(address(this)) == 0, "Reward token not completely claimed by everyone yet")`. New issue is introduced: having balance required to be strictly  equal to zero make it exposed to a scenario in which reward tokens with small uncollectible residues are not possible to be removed. A scenario is reproduced in a Proof of Concept test. 
Recommendation - will be to adjust numbers, in terms of tokenomics of the project, in a way to deal with this or make sure the last staker collecting reward is actually collecting everything by rounding up the division in certain occasions rather than rounding down each time.

Remove `removeApprovedRewardToken` completely because it is very difficult to get all the users to claim their rewards till 0 anyway. We are also adding a non-zero check before transferring the reward tokens to save on gas for users because of this change.